### PR TITLE
feat: update passion prompt

### DIFF
--- a/.condarc
+++ b/.condarc
@@ -1,1 +1,2 @@
 auto_activate_base: false
+changeps1: false

--- a/config/zsh/themes/passion.zsh-theme
+++ b/config/zsh/themes/passion.zsh-theme
@@ -47,6 +47,10 @@ function login_info() {
     echo "${color}[%n@${ip}]${color_reset}";
 }
 
+# conda environment
+function conda_info() {
+    echo "%{$fg[magenta]%}(${CONDA_DEFAULT_ENV})%{$reset_color%}"
+}
 
 # directory
 function directory() {
@@ -209,5 +213,13 @@ TRAPALRM() { # cspell:disable-line
 
 
 # prompt
+function _passion_prompt() {
+    if [ -v CONDA_DEFAULT_ENV ]; then
+      echo "$(real_time) $(conda_info) $(directory) $(git_status)$(command_status) "
+    else
+      echo "$(real_time) $(directory) $(git_status)$(command_status) "
+    fi
+}
+
 # PROMPT='$(real_time) $(login_info) $(directory) $(git_status)$(command_status) ';
-PROMPT='$(real_time) $(directory) $(git_status)$(command_status) ';
+PROMPT='$(_passion_prompt)';

--- a/scripts/zsh_setup.sh
+++ b/scripts/zsh_setup.sh
@@ -2,17 +2,17 @@
 
 # Ensure .oh-my-zsh is already installed
 if [[ -z "${ZSH}" || ! -d "${ZSH}" ]]; then
-  echo ".oh-my-zsh is not installed. Please install it first."
-  exit 1
+	echo ".oh-my-zsh is not installed. Please install it first."
+	exit 1
 fi
 
 # Assert ZSH_CUSTOM exists
 if [ -z "${ZSH_CUSTOM}" ]; then
-  ZSH_CUSTOM="${ZSH}/custom"
+	ZSH_CUSTOM="${ZSH}/custom"
 fi
 
-# Download modified passion.zsh-theme from saved config
-cp "${HOME}/.dotfiles/config/zsh/themes/passion.zsh-theme" "${ZSH_CUSTOM}"/themes
+# Symlink modified passion theme to ZSH_CUSTOM
+ln -s "${HOME}/.dotfiles/config/zsh/themes/passion.zsh-theme" "${ZSH_CUSTOM}"/themes
 
 # Download zsh-autosuggestions plugin
 git clone https://github.com/zsh-users/zsh-autosuggestions "${ZSH_CUSTOM}"/plugins/zsh-autosuggestions


### PR DESCRIPTION
Updates Passion prompt to colourize `conda` environment and shift it after `current_time`.

Moreover, retains normal view if `conda` not active.

![Screenshot 2023-10-19 at 11 52 08](https://github.com/john-s-lin/dotfiles/assets/66440371/c749cd53-14cc-4796-9367-3feee0a3c187)

Inspired by https://github.com/philip82148/simplerich-zsh-theme
