### PR TITLE
feat: add linux support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,51 +2,29 @@
 
 # Ensure you are running as root
 if [[ ${EUID} = 0 ]]; then
-  echo "(1) Running as superuser already."
+	echo "(1) Running as superuser already."
 else
-  # Reset user as superuser
-  sudo -k
-  if sudo true; then
-    echo "(2) User changed to sudo."
-  else
-    echo "(3) Wrong password."
-    exit 1
-  fi
+	# Reset user as superuser
+	sudo -k
+	if sudo true; then
+		echo "(2) User changed to sudo."
+	else
+		echo "(3) Wrong password."
+		exit 1
+	fi
 fi
 
-# Install Xcode CLT
-xcode-select --install
+OS="$(uname -s)"
 
-# Install Homebrew
-echo "Checking for Homebrew..."
-if test ! "$(which brew)"; then
-    echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    echo "Homebrew installed!"
+if [[ "$OS" == "Darwin" ]]; then
+	echo "Running install script for MacOS..."
+	source install_macos.sh
+elif [[ "$OS" == "Linux" ]]; then
+	echo "Running install script for Linux..."
+	source install_linux.sh
 else
-    echo "$(brew --version) already installed."
+	echo "Not a supported OS. Exiting..."
+	exit 1
 fi
 
-# Check brew doctor
-brew doctor
-
-# Install brew packages from Brewfile
-brew bundle install -v --file="$(pwd)"/Brewfile
-
-# Install oh-my-zsh
-# TODO oh-my-zsh install messes up the rest of the script
-# Figure out a way to install this in a separate terminal
-# chmod u+x "$(pwd)"/scripts/zsh_setup.sh
-# sh -c "$(pwd)"/scripts/zsh_setup.sh
-
-# Install fzf autocompletion and key bindings
-if test "$(which fzf)"; then
-    echo "Installing fzf autocomplete and key bindings..."
-    "$(brew --prefix)"/opt/fzf/install
-fi
-
-# Initialize miniconda
-conda init "$(basename "${SHELL}")"
-
-# Disable Microsoft AutoUpdate
-launchctl disable gui/"$(id -u)"/com.microsoft.update.agent
+exit 0

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "TBD"
+
+exit 0

--- a/install_macos.sh
+++ b/install_macos.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+if [[ "$OS" != "Darwin" ]]; then
+	echo "Oops! $OS is not MacOS. Running the wrong install script. Exiting..."
+	exit 1
+fi
+
+# Install Xcode CLT
+xcode-select --install
+
+# Install Homebrew
+echo "Checking for Homebrew..."
+if test ! "$(which brew)"; then
+	echo "Installing Homebrew..."
+	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+	echo "Homebrew installed!"
+else
+	echo "$(brew --version) already installed."
+fi
+
+# Check brew doctor
+brew doctor
+
+# Install brew packages from Brewfile
+brew bundle install -v --file="$(pwd)"/Brewfile
+
+# Install oh-my-zsh
+# TODO oh-my-zsh install messes up the rest of the script
+# Figure out a way to install this in a separate terminal
+# chmod u+x "$(pwd)"/scripts/zsh_setup.sh
+# sh -c "$(pwd)"/scripts/zsh_setup.sh
+
+# Install fzf autocompletion and key bindings
+if test "$(which fzf)"; then
+	echo "Installing fzf autocomplete and key bindings..."
+	"$(brew --prefix)"/opt/fzf/install
+fi
+
+# Initialize miniconda
+conda init "$(basename "${SHELL}")"
+
+# Disable Microsoft AutoUpdate
+launchctl disable gui/"$(id -u)"/com.microsoft.update.agent
+
+exit 0


### PR DESCRIPTION
Defers install of configuration files of Unix-like OSes to OS-specific install scripts.

Does not close #5 as I still have to figure out what dependencies are necessary for my personal Linux setup. 

As of right now:
 - Docker
 - pihole (Raspberry Pi only)
 - k3s (optional)
 - LLVM (optional)
 