### PR TITLE
feat: add `bat` config

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,1 +1,4 @@
 alias lg="lazygit"
+if command -v bat &>/dev/null; then
+	alias cat="bat"
+fi

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,4 +1,7 @@
-alias lg="lazygit"
+if command -v lazygit &>/dev/null; then
+	alias lg="lazygit"
+fi
+
 if command -v bat &>/dev/null; then
 	alias cat="bat"
 fi

--- a/Brewfile
+++ b/Brewfile
@@ -4,6 +4,8 @@ tap "homebrew/services"
 tap "oven-sh/bun"
 
 # List
+# A better cat(1)
+brew "bat"
 # TUI System Metrics
 brew "bottom"
 # Bun

--- a/config/bat/config
+++ b/config/bat/config
@@ -1,0 +1,2 @@
+# Set the theme to "TwoDark"
+--theme="TwoDark"

--- a/scripts/symlinks.sh
+++ b/scripts/symlinks.sh
@@ -21,17 +21,13 @@ ln -sfn "${DOTFILES_ROOT}/.gitconfig" "${HOME}/.gitconfig"
 # Symlink config settings
 mkdir -p "${HOME}/.config"
 
-ln -sfn "${DOTFILES_ROOT}/config/nvim" "${HOME}/.config/nvim"
-ln -sfn "${DOTFILES_ROOT}/config/tmux" "${HOME}/.config/tmux"
 ln -sfn "${DOTFILES_ROOT}/config/alacritty" "${HOME}/.config/alacritty"
-ln -sfn "${DOTFILES_ROOT}/config/zed" "${HOME}/.config/zed"
 ln -sfn "${DOTFILES_ROOT}/config/bat" "${HOME}/.config/bat"
+ln -sfn "${DOTFILES_ROOT}/config/bottom" "${HOME}/.config/bottom"
 ln -sfn "${DOTFILES_ROOT}/config/ghostty" "${HOME}/.config/ghostty"
+ln -sfn "${DOTFILES_ROOT}/config/nvim" "${HOME}/.config/nvim"
 ln -sfn "${DOTFILES_ROOT}/config/starship" "${HOME}/.config/starship"
-
-# If bottom exists, symlink bottom.toml config
-if command -v btm >/dev/null 2>&1; then
-	ln -sfn "${DOTFILES_ROOT}/config/bottom" "${HOME}/.config/bottom"
-fi
+ln -sfn "${DOTFILES_ROOT}/config/tmux" "${HOME}/.config/tmux"
+ln -sfn "${DOTFILES_ROOT}/config/zed" "${HOME}/.config/zed"
 
 exit 0

--- a/scripts/symlinks.sh
+++ b/scripts/symlinks.sh
@@ -25,6 +25,7 @@ ln -sfn "${DOTFILES_ROOT}/config/nvim" "${HOME}/.config/nvim"
 ln -sfn "${DOTFILES_ROOT}/config/tmux" "${HOME}/.config/tmux"
 ln -sfn "${DOTFILES_ROOT}/config/alacritty" "${HOME}/.config/alacritty"
 ln -sfn "${DOTFILES_ROOT}/config/zed" "${HOME}/.config/zed"
+ln -sfn "${DOTFILES_ROOT}/config/bat" "${HOME}/.config/bat"
 ln -sfn "${DOTFILES_ROOT}/config/ghostty" "${HOME}/.config/ghostty"
 ln -sfn "${DOTFILES_ROOT}/config/starship" "${HOME}/.config/starship"
 


### PR DESCRIPTION
Resolves #15 

- Aliases `cat` to `bat` if `bat` exists
- Adds `theme=TwoDark` to config
- Adds symlink script
- Adds to Brewfile