### PR TITLE
feat: move home-manager to be built by nixos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
 HOSTNAME?=john-nix-05
-USER?=john
 GC_DAYS?=30
 
 # Run nixos-rebuild
 nr:
 	sudo nixos-rebuild switch --flake .#$(HOSTNAME)
-
-# Run home-manager
-hm:
-	home-manager switch --flake .#$(USER)
 
 # Run garbage-collect
 gc:

--- a/flake.nix
+++ b/flake.nix
@@ -40,21 +40,5 @@
         specialArgs = { inherit inputs system; };
         modules = [ ./hosts/john-nix-05/configuration.nix ];
       };
-      homeConfigurations = {
-        john = home-manager.lib.homeManagerConfiguration {
-          inherit pkgs;
-          extraSpecialArgs = {
-            inherit
-              inputs
-              dotfiles
-              nixvim
-              system
-              ;
-          };
-          modules = [
-            ./hosts/john-nix-05/home.nix
-          ];
-        };
-      };
     };
 }

--- a/hosts/john-nix-05/configuration.nix
+++ b/hosts/john-nix-05/configuration.nix
@@ -70,6 +70,13 @@
     shell = pkgs.zsh;
   };
 
+  home-manager.users.john = { pkgs, ... }: {
+    imports = [
+      ./home.nix
+      inputs.nixvim.homeManagerModules.nixvim
+    ];
+  }
+
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.
   # programs.mtr.enable = true;

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -1,6 +1,6 @@
 {
   config,
-  dotfiles,
+  inputs,
   ...
 }:
 {
@@ -71,12 +71,12 @@
   # plain files is through 'home.file'.
   home.file = {
     ".config/alacritty" = {
-      source = "${dotfiles}/config/alacritty";
+      source = "${inputs.dotfiles}/config/alacritty";
       recursive = true;
     };
     # Copy only the themes over. Zed configuration is covered by ../../modules/home/zed.nix
     ".config/zed/themes" = {
-      source = "${dotfiles}/config/zed/themes";
+      source = "${inputs.dotfiles}/config/zed/themes";
       recursive = true;
     };
   };


### PR DESCRIPTION
`home-manager` will no longer be standalone but built when nixos-rebuild happens

Fixes #12 