### PR TITLE
feat: rclone darwin

### DIFF
--- a/docs/cloud-storage.md
+++ b/docs/cloud-storage.md
@@ -9,3 +9,9 @@ rclone config
 ```
 
 Follow the instructions for both OneDrive and Google Drive, login through the web interfaces and you should be good to go! Configuration tokens will be stored locally in `${XDG_CONFIG_HOME}/rclone/rclone.conf`.
+
+## MacOS
+
+For MacOS `nix-darwin` systems, you need to enable `macFUSE` by allowing system extensions to have access to the kernel in order to mount the remote drives.
+
+The documentation for this is available at https://github.com/macfuse/macfuse/wiki/Getting-Started.

--- a/hosts/john-air-03/configuration.nix
+++ b/hosts/john-air-03/configuration.nix
@@ -5,6 +5,7 @@
     ../../modules/darwin/packages/common.nix
     ../../modules/darwin/packages/mas.nix
     ../../modules/darwin/packages/personal.nix
+    ../../modules/darwin/packages/rclone.nix
     ../../modules/darwin/packages/work.nix
     ../../modules/darwin/defaults.nix
   ];

--- a/hosts/john-axl-06/configuration.nix
+++ b/hosts/john-axl-06/configuration.nix
@@ -5,6 +5,7 @@
     ../../modules/darwin/packages/common.nix
     ../../modules/darwin/packages/ai.nix
     ../../modules/darwin/packages/axl.nix
+    ../../modules/darwin/packages/rclone.nix
     ../../modules/darwin/defaults.nix
   ];
 

--- a/modules/darwin/packages/rclone.nix
+++ b/modules/darwin/packages/rclone.nix
@@ -1,6 +1,10 @@
+{ pkgs, ... }:
 {
+  environment.systemPackages = with pkgs; [
+    rclone
+  ];
+
   homebrew = {
     casks = [ "macfuse" ];
-    brews = [ "rclone" ];
   };
 }

--- a/modules/darwin/packages/rclone.nix
+++ b/modules/darwin/packages/rclone.nix
@@ -1,0 +1,6 @@
+{
+  homebrew = {
+    casks = [ "macfuse" ];
+    brews = [ "rclone" ];
+  };
+}

--- a/modules/darwin/packages/rclone.nix
+++ b/modules/darwin/packages/rclone.nix
@@ -1,4 +1,8 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
+let
+  username = "john";
+  homeDir = config.users.users.${username}.home;
+in
 {
   environment.systemPackages = with pkgs; [
     rclone
@@ -6,5 +10,40 @@
 
   homebrew = {
     casks = [ "macfuse" ];
+  };
+
+  launchd.user.agents = {
+    rclone-onedrive = {
+      serviceConfig = {
+        ProgramArguments = [
+          "/bin/sh"
+          "-c"
+          "mkdir -p ${homeDir}/OneDrive && ${pkgs.rclone}/bin/rclone --vfs-cache-mode writes --config=${homeDir}/.config/rclone/rclone.conf --ignore-checksum mount OneDrive: ${homeDir}/OneDrive"
+        ];
+        RunAtLoad = true;
+        KeepAlive = {
+          Crashed = true;
+          SuccessfulExit = false;
+        };
+        StandardOutPath = "${homeDir}/Library/Logs/rclone-onedrive.log";
+        StandardErrorPath = "${homeDir}/Library/Logs/rclone-onedrive.err.log";
+      };
+    };
+    rclone-gdrive = {
+      serviceConfig = {
+        ProgramArguments = [
+          "/bin/sh"
+          "-c"
+          "mkdir -p ${homeDir}/GDrive && ${pkgs.rclone}/bin/rclone --vfs-cache-mode writes --config=${homeDir}/.config/rclone/rclone.conf --ignore-checksum mount GDrive: ${homeDir}/GDrive"
+        ];
+        RunAtLoad = true;
+        KeepAlive = {
+          Crashed = true;
+          SuccessfulExit = false;
+        };
+        StandardOutPath = "${homeDir}/Library/Logs/rclone-gdrive.log";
+        StandardErrorPath = "${homeDir}/Library/Logs/rclone-gdrive.err.log";
+      };
+    };
   };
 }


### PR DESCRIPTION
This PR enables mounting of remote drives on `nix-darwin` machines. 

No more installing OneDrive through `mas` and no more Google Drive through `brew`, which installs unnecessary "web app" bs!