### PR TITLE
feat: migrate john-nix-05 from GNOME to COSMIC DE, add Papers PDF viewer

### DIFF
--- a/hosts/john-nix-05/configuration.nix
+++ b/hosts/john-nix-05/configuration.nix
@@ -9,7 +9,7 @@
     # Include the results of the hardware scan.
     ./hardware-configuration.nix
 
-    ../../modules/desktop/gnome.nix
+    ../../modules/desktop/cosmic.nix
     ../../modules/desktop/hyprland.nix
     ../../modules/fonts.nix
     ../../modules/packages/default.nix

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  services = {
+    displayManager.cosmic-greeter.enable = true;
+    desktopManager.cosmic.enable = true;
+  };
+
+  # Exclude COSMIC apps that duplicate existing tools
+  environment.cosmic.excludePackages = with pkgs; [
+    cosmic-edit # using Helix/Zed
+    cosmic-term # using Ghostty
+    cosmic-player # using VLC
+  ];
+}

--- a/modules/desktop/hypr/default.nix
+++ b/modules/desktop/hypr/default.nix
@@ -4,7 +4,7 @@
 }:
 let
   terminal = "ghostty";
-  fileManager = "nautilus";
+  fileManager = "cosmic-files";
   menu = "rofi -show drun";
   secondMonitor = "DP-2";
 in

--- a/modules/packages/personal.nix
+++ b/modules/packages/personal.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
+    papers
     qbittorrent
     signal-desktop
     vesktop


### PR DESCRIPTION
Closes #51

## Summary

- Replace GNOME DE + GDM with COSMIC DE + `cosmic-greeter` on `john-nix-05`
- Hyprland remains as a parallel session, fully unaffected
- Add `papers` (GNOME's GTK4 document viewer) as a macOS Preview equivalent
- Swap Hyprland's file manager from `nautilus` → `cosmic-files`

## Changes

| File | Change |
|---|---|
| `modules/desktop/cosmic.nix` | **New** — enables `cosmic-greeter` + COSMIC DE, excludes `cosmic-edit`/`cosmic-term`/`cosmic-player` (duplicated by Helix, Ghostty, VLC) |
| `hosts/john-nix-05/configuration.nix` | Swap import `gnome.nix` → `cosmic.nix` |
| `modules/desktop/hypr/default.nix` | `fileManager`: `nautilus` → `cosmic-files` |
| `modules/packages/personal.nix` | Add `papers` to `home.packages` |

`modules/desktop/gnome.nix` is **preserved** (not deleted) for easy rollback.

## Notes

- No `flake.nix` or `flake.lock` changes — COSMIC is in upstream nixpkgs (`nixos-unstable`)
- GNOME Keyring continues to work: COSMIC's NixOS module enables it by default; Hyprland's `exec-once` for `gnome-keyring-daemon` remains valid
- COSMIC is beta in NixOS 25.11 — expect rough edges in the COSMIC session; Hyprland session is unaffected
- COSMIC settings are not declarative (RON files under `~/.config/cosmic/`); no home-manager module exists yet
- Verified: `nix flake check --no-build` passes cleanly