### PR TITLE
feat: add alacritty.nix module, remove dotfiles symlink

### DIFF
--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -25,6 +25,7 @@ in
     ../../modules/desktop/hypr/default.nix
 
     # Host-specific config
+    ../../modules/home/alacritty.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
@@ -64,7 +65,6 @@ in
   # Home Manager is pretty good at managing dotfiles. The primary way to manage
   # plain files is through 'home.file'.
   home.file = {
-    ".config/alacritty".source = mkDotfilesSymlink "config/alacritty";
     ".config/zed".source = mkDotfilesSymlink "config/zed";
     ".config/ghostty/themes".source = mkDotfilesSymlink "config/ghostty/themes";
   };

--- a/modules/home/alacritty.nix
+++ b/modules/home/alacritty.nix
@@ -1,0 +1,74 @@
+{
+  programs = {
+    alacritty = {
+      enable = true;
+
+      settings = {
+        general = {
+          live_config_reload = true;
+        };
+
+        window = {
+          decorations = "None";
+          opacity = 1.0;
+          blur = false;
+          dynamic_padding = true;
+          padding = {
+            x = 5;
+            y = 5;
+          };
+        };
+
+        font = {
+          normal = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Regular";
+          };
+          bold = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Bold";
+          };
+          italic = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Italic";
+          };
+          bold_italic = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Bold Italic";
+          };
+          size = 12;
+        };
+
+        # Tokyo Night theme
+        colors = {
+          primary = {
+            background = "#1a1b26";
+            foreground = "#a9b1d6";
+          };
+
+          normal = {
+            black = "#32344a";
+            red = "#f7768e";
+            green = "#9ece6a";
+            yellow = "#e0af68";
+            blue = "#7aa2f7";
+            magenta = "#ad8ee6";
+            cyan = "#449dab";
+            white = "#787c99";
+          };
+
+          bright = {
+            black = "#444b6a";
+            red = "#ff7a93";
+            green = "#b9f27c";
+            yellow = "#ff9e64";
+            blue = "#7da6ff";
+            magenta = "#bb9af7";
+            cyan = "#0db9d7";
+            white = "#acb0d0";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Create `modules/home/alacritty.nix` with `programs.alacritty` configuration
- Port Tokyo Night theme, font settings, window config from dotfiles
- Remove dotfiles symlink from `john-nix-05/home.nix`

## Details

Converts Alacritty from dotfiles symlink to native Home Manager module:
- Uses `programs.alacritty` with inline settings
- Tokyo Night theme fully inlined (no external file dependency)
- Font configuration: JetBrainsMono Nerd Font Mono with all variants (normal, bold, italic, bold-italic)
- Window config: decorations, padding, opacity

## Validation

- `nix flake check --no-build` passes
- `nix build .#nixosConfigurations.john-nix-05` builds successfully

Part of [infra#53](https://github.com/john-s-lin/infra/issues/53) migration (Route B: Nix as single source of truth)