### PR TITLE
feat: add zed.nix module, remove dotfiles symlinks

### DIFF
--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -12,6 +12,7 @@ in
     ../../modules/home/workstation.nix
 
     # Additional config
+    ../../modules/home/zed.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/zsh.nix
@@ -29,7 +30,6 @@ in
   home.file = {
     ".config/ghostty".source = mkDotfilesSymlink "config/ghostty";
     ".bashrc".source = mkDotfilesSymlink ".bashrc";
-    ".config/zed".source = mkDotfilesSymlink "config/zed";
   };
 
   # Set your Home Manager state version.

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -16,6 +16,7 @@ in
     ../../modules/home/workstation.nix
 
     # Additional config
+    ../../modules/home/zed.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/zsh.nix
@@ -38,7 +39,6 @@ in
   home.file = {
     ".config/ghostty".source = mkDotfilesSymlink "config/ghostty";
     ".bashrc".source = mkDotfilesSymlink ".bashrc";
-    ".config/zed".source = mkDotfilesSymlink "config/zed";
   };
 
   # Set your Home Manager state version.

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -26,6 +26,7 @@ in
 
     # Host-specific config
     ../../modules/home/alacritty.nix
+    ../../modules/home/zed.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
@@ -65,7 +66,6 @@ in
   # Home Manager is pretty good at managing dotfiles. The primary way to manage
   # plain files is through 'home.file'.
   home.file = {
-    ".config/zed".source = mkDotfilesSymlink "config/zed";
     ".config/ghostty/themes".source = mkDotfilesSymlink "config/ghostty/themes";
   };
 

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -25,6 +25,7 @@ in
     ../../modules/desktop/hypr/default.nix
 
     # Host-specific config
+    ../../modules/home/alacritty.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
@@ -64,7 +65,6 @@ in
   # Home Manager is pretty good at managing dotfiles. The primary way to manage
   # plain files is through 'home.file'.
   home.file = {
-    ".config/alacritty".source = mkDotfilesSymlink "config/alacritty";
     ".config/zed".source = mkDotfilesSymlink "config/zed";
     ".config/ghostty/themes".source = mkDotfilesSymlink "config/ghostty/themes";
   };

--- a/modules/home/alacritty.nix
+++ b/modules/home/alacritty.nix
@@ -1,0 +1,74 @@
+{
+  programs = {
+    alacritty = {
+      enable = true;
+
+      settings = {
+        general = {
+          live_config_reload = true;
+        };
+
+        window = {
+          decorations = "None";
+          opacity = 1.0;
+          blur = false;
+          dynamic_padding = true;
+          padding = {
+            x = 5;
+            y = 5;
+          };
+        };
+
+        font = {
+          normal = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Regular";
+          };
+          bold = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Bold";
+          };
+          italic = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Italic";
+          };
+          bold_italic = {
+            family = "JetBrainsMono Nerd Font Mono";
+            style = "Bold Italic";
+          };
+          size = 12;
+        };
+
+        # Tokyo Night theme
+        colors = {
+          primary = {
+            background = "#1a1b26";
+            foreground = "#a9b1d6";
+          };
+
+          normal = {
+            black = "#32344a";
+            red = "#f7768e";
+            green = "#9ece6a";
+            yellow = "#e0af68";
+            blue = "#7aa2f7";
+            magenta = "#ad8ee6";
+            cyan = "#449dab";
+            white = "#787c99";
+          };
+
+          bright = {
+            black = "#444b6a";
+            red = "#ff7a93";
+            green = "#b9f27c";
+            yellow = "#ff9e64";
+            blue = "#7da6ff";
+            magenta = "#bb9af7";
+            cyan = "#0db9d7";
+            white = "#acb0d0";
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/home/zed.nix
+++ b/modules/home/zed.nix
@@ -1,0 +1,74 @@
+{ lib, pkgs, ... }:
+let
+  # Zed settings - platform-specific
+  # On Linux: use programs.zed-editor with userSettings
+  # On Darwin: use xdg.configFile since Zed is installed via Homebrew
+  zedSettings = {
+    features = {
+      edit_prediction_provider = "none";
+    };
+    auto_install_extensions = {
+      html = false;
+    };
+    auto_update = false;
+    base_keymap = "VSCode";
+    buffer_font_family = "JetBrainsMono Nerd Font Mono";
+    buffer_font_size = 13;
+    colorize_brackets = true;
+    disable_ai = true;
+    format_on_save = "on";
+    git_panel = {
+      dock = "right";
+    };
+    preferred_line_length = 120;
+    project_panel = {
+      dock = "left";
+    };
+    relative_line_numbers = "enabled";
+    telemetry = {
+      diagnostics = false;
+      metrics = false;
+    };
+    terminal = {
+      line_height = "standard";
+    };
+    theme = "One Dark Pro";
+    ui_font_family = "Geist";
+    ui_font_size = 16;
+    vim_mode = true;
+    languages = {
+      Nix = {
+        language_servers = [
+          "nil"
+          "!nixd"
+        ];
+        formatter = {
+          external = {
+            command = "nixfmt";
+          };
+        };
+      };
+      Python = {
+        language_servers = [
+          "!ty"
+          "basedpyright"
+          "ruff"
+        ];
+      };
+    };
+  };
+in
+{
+  # Linux: use programs.zed-editor
+  programs.zed-editor = lib.optionalAttrs pkgs.stdenv.isLinux {
+    enable = true;
+    userSettings = zedSettings;
+  };
+
+  # Darwin: use xdg.configFile since Zed is installed via Homebrew
+  home.file = lib.optionalAttrs pkgs.stdenv.isDarwin {
+    ".config/zed/settings.json" = {
+      text = builtins.toJSON zedSettings;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Create `modules/home/zed.nix` with `programs.zed-editor` configuration
- Port settings from dotfiles (VSCode keymap, vim_mode, fonts, theme, language servers)
- Use `programs.zed-editor` on Linux, `xdg.configFile` on Darwin (since Zed is Homebrew-installed on macOS)
- Remove zed dotfiles symlinks from all host `home.nix` files

## Details

Converts Zed from dotfiles symlink to native Home Manager module:
- Linux: Uses `programs.zed-editor` with `userSettings`
- Darwin: Uses `xdg.configFile` (Zed installed via Homebrew)
- Settings: base_keymap, vim_mode, fonts, telemetry off, language servers (Nix→nil+nixfmt, Python→basedpyright+ruff)

## Validation

- `nix flake check --no-build` passes

Part of [infra#53](https://github.com/john-s-lin/infra/issues/53) migration (Route B: Nix as single source of truth)