### PR TITLE
feat: migrate alacritty from dotfiles config to nix

### DIFF
--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -25,6 +25,7 @@ in
     ../../modules/desktop/hypr/default.nix
 
     # Host-specific config
+    ../../modules/home/alacritty.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
@@ -64,7 +65,6 @@ in
   # Home Manager is pretty good at managing dotfiles. The primary way to manage
   # plain files is through 'home.file'.
   home.file = {
-    ".config/alacritty".source = mkDotfilesSymlink "config/alacritty";
     ".config/zed".source = mkDotfilesSymlink "config/zed";
     ".config/ghostty/themes".source = mkDotfilesSymlink "config/ghostty/themes";
   };

--- a/modules/home/alacritty.nix
+++ b/modules/home/alacritty.nix
@@ -1,0 +1,69 @@
+{
+  programs.alacritty = {
+    enable = true;
+
+    # Note live_config_reload is not carried over since config is managed by nix
+    # which is certainly not live
+    settings = {
+
+      window = {
+        decorations = "None";
+        opacity = 1.0;
+        blur = false;
+        dynamic_padding = true;
+        padding = {
+          x = 5;
+          y = 5;
+        };
+      };
+
+      font = {
+        normal = {
+          family = "JetBrainsMono Nerd Font Mono";
+          style = "Regular";
+        };
+        bold = {
+          family = "JetBrainsMono Nerd Font Mono";
+          style = "Bold";
+        };
+        italic = {
+          family = "JetBrainsMono Nerd Font Mono";
+          style = "Italic";
+        };
+        bold_italic = {
+          family = "JetBrainsMono Nerd Font Mono";
+          style = "Bold Italic";
+        };
+        size = 12;
+      };
+
+      # Tokyo Night
+      colors = {
+        primary = {
+          background = "#1a1b26";
+          foreground = "#a9b1d6";
+        };
+        normal = {
+          black = "#32344a";
+          red = "#f7768e";
+          green = "#9ece6a";
+          yellow = "#e0af68";
+          blue = "#7aa2f7";
+          magenta = "#ad8ee6";
+          cyan = "#449dab";
+          white = "#787c99";
+        };
+        bright = {
+          black = "#444b6a";
+          red = "#ff7a93";
+          green = "#b9f27c";
+          yellow = "#ff9e64";
+          blue = "#7da6ff";
+          magenta = "#bb9af7";
+          cyan = "#0db9d7";
+          white = "#acb0d0";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Actually migrate from alacritty config in dotfiles to using nix. We don't use alacritty on any of the nix-darwin machines so the only config that carries over is for the host/john-nix-05