### PR TITLE
feat: migrate zed from dotfiles config to nix

### DIFF
--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -30,7 +30,6 @@ in
   home.file = {
     ".config/ghostty".source = mkDotfilesSymlink "config/ghostty";
     ".bashrc".source = mkDotfilesSymlink ".bashrc";
-    ".config/zed".source = mkDotfilesSymlink "config/zed";
   };
 
   # Set your Home Manager state version.

--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -14,6 +14,7 @@ in
     # Additional config
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
+    ../../modules/home/zed.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -18,6 +18,7 @@ in
     # Additional config
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
+    ../../modules/home/zed.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -39,7 +39,6 @@ in
   home.file = {
     ".config/ghostty".source = mkDotfilesSymlink "config/ghostty";
     ".bashrc".source = mkDotfilesSymlink ".bashrc";
-    ".config/zed".source = mkDotfilesSymlink "config/zed";
   };
 
   # Set your Home Manager state version.

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -66,7 +66,6 @@ in
   # Home Manager is pretty good at managing dotfiles. The primary way to manage
   # plain files is through 'home.file'.
   home.file = {
-    ".config/zed".source = mkDotfilesSymlink "config/zed";
     ".config/ghostty/themes".source = mkDotfilesSymlink "config/ghostty/themes";
   };
 

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -30,6 +30,7 @@ in
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/rclone.nix
+    ../../modules/home/zed.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/modules/home/zed.nix
+++ b/modules/home/zed.nix
@@ -1,0 +1,358 @@
+{ pkgs, lib, ... }:
+let
+  zedSettings = {
+    features = {
+      edit_prediction_provider = "none";
+    };
+    auto_install_extensions = {
+      html = false;
+    };
+    auto_update = false;
+    base_keymap = "VSCode";
+    buffer_font_family = "JetBrainsMono Nerd Font Mono";
+    buffer_font_size = 13;
+    colorize_brackets = true;
+    disable_ai = true;
+    format_on_save = "on";
+    git_panel = {
+      dock = "right";
+    };
+    preferred_line_length = 120;
+    project_panel = {
+      dock = "left";
+    };
+    relative_line_numbers = "enabled";
+    telemetry = {
+      diagnostics = false;
+      metrics = false;
+    };
+    terminal = {
+      line_height = "standard";
+    };
+    theme = "One Dark Pro";
+    ui_font_family = "Geist";
+    ui_font_size = 16;
+    vim_mode = true;
+    helix_mode = true;
+    languages = {
+      Nix = {
+        language_servers = [
+          "nil"
+          "!nixd"
+        ];
+        formatter = {
+          external = {
+            command = "nixfmt";
+          };
+        };
+      };
+      Python = {
+        language_servers = [
+          "!ty"
+          "basedpyright"
+          "ruff"
+        ];
+      };
+    };
+  };
+
+  zedTheme = {
+    name = "One Dark Pro";
+    author = "One Dark Pro: Zed Theme Importer";
+    themes = [
+      {
+        name = "One Dark Pro";
+        appearance = "dark";
+        style = {
+          "border" = "#3e4452";
+          "border.variant" = "#3e4452";
+          "border.focused" = "#3e4452";
+          "border.selected" = "#3e4452";
+          "border.transparent" = "#3e4452";
+          "border.disabled" = "#3e4452";
+          "elevated_surface.background" = "#1e2227";
+          "surface.background" = "#23272e";
+          "background" = "#23272e";
+          "element.background" = "#404754";
+          "element.hover" = "#2c313a";
+          "element.active" = null;
+          "element.selected" = "#2c313a";
+          "element.disabled" = null;
+          "drop_target.background" = null;
+          "ghost_element.background" = null;
+          "ghost_element.hover" = "#2c313a";
+          "ghost_element.active" = null;
+          "ghost_element.selected" = "#2c313a";
+          "ghost_element.disabled" = null;
+          "text" = null;
+          "text.muted" = null;
+          "text.placeholder" = null;
+          "text.disabled" = null;
+          "text.accent" = null;
+          "icon" = null;
+          "icon.muted" = null;
+          "icon.disabled" = null;
+          "icon.placeholder" = null;
+          "icon.accent" = null;
+          "status_bar.background" = "#1e2227";
+          "title_bar.background" = "#23272e";
+          "toolbar.background" = "#23272e";
+          "tab_bar.background" = "#1e2227";
+          "tab.inactive_background" = "#1e2227";
+          "tab.active_background" = "#23272e";
+          "search.match_background" = "#d19a6644";
+          "panel.background" = "#23272e";
+          "panel.focused_border" = null;
+          "scrollbar_thumb.background" = "#4e5666";
+          "scrollbar.thumb.hover_background" = "#5a6375";
+          "scrollbar.thumb.border" = "#4e5666";
+          "scrollbar.track.background" = "#23272e";
+          "scrollbar.track.border" = null;
+          "editor.foreground" = "#abb2bf";
+          "editor.background" = "#23272e";
+          "editor.gutter.background" = "#23272e";
+          "editor.subheader.background" = null;
+          "editor.active_line.background" = "#2c313c";
+          "editor.highlighted_line.background" = null;
+          "editor.line_number" = "#495162";
+          "editor.active_line_number" = "#abb2bf";
+          "editor.invisible" = null;
+          "editor.wrap_guide" = "#3e4452";
+          "editor.active_wrap_guide" = "#3e4452";
+          "editor.document_highlight.read_background" = null;
+          "editor.document_highlight.write_background" = null;
+          "editor.document_highlight.bracket_background" = "#515a6b";
+          "terminal.background" = "#23272e";
+          "terminal.foreground" = null;
+          "terminal.bright_foreground" = null;
+          "terminal.dim_foreground" = null;
+          "terminal.ansi.black" = "#3f4451";
+          "terminal.ansi.bright_black" = "#4f5666";
+          "terminal.ansi.dim_black" = null;
+          "terminal.ansi.red" = "#e05561";
+          "terminal.ansi.bright_red" = "#ff616e";
+          "terminal.ansi.dim_red" = null;
+          "terminal.ansi.green" = "#8cc265";
+          "terminal.ansi.bright_green" = "#a5e075";
+          "terminal.ansi.dim_green" = null;
+          "terminal.ansi.yellow" = "#d18f52";
+          "terminal.ansi.bright_yellow" = "#f0a45d";
+          "terminal.ansi.dim_yellow" = null;
+          "terminal.ansi.blue" = "#4aa5f0";
+          "terminal.ansi.bright_blue" = "#4dc4ff";
+          "terminal.ansi.dim_blue" = null;
+          "terminal.ansi.magenta" = "#c162de";
+          "terminal.ansi.bright_magenta" = "#de73ff";
+          "terminal.ansi.dim_magenta" = null;
+          "terminal.ansi.cyan" = "#42b3c2";
+          "terminal.ansi.bright_cyan" = "#4cd1e0";
+          "terminal.ansi.dim_cyan" = null;
+          "terminal.ansi.white" = "#d7dae0";
+          "terminal.ansi.bright_white" = "#e6e6e6";
+          "terminal.ansi.dim_white" = null;
+          "link_text.hover" = null;
+          "conflict" = null;
+          "conflict.background" = null;
+          "conflict.border" = null;
+          "created" = "#a5e075";
+          "created.background" = null;
+          "created.border" = null;
+          "deleted" = "#ff616e";
+          "deleted.background" = null;
+          "deleted.border" = null;
+          "error" = "#c24038";
+          "error.background" = "#1e2227";
+          "error.border" = "#a03237";
+          "hidden" = null;
+          "hidden.background" = null;
+          "hidden.border" = null;
+          "hint" = "#7a849c";
+          "hint.background" = "#1e2227";
+          "hint.border" = "#013b64";
+          "ignored" = "#636b78";
+          "ignored.background" = null;
+          "ignored.border" = null;
+          "info" = null;
+          "info.background" = null;
+          "info.border" = null;
+          "modified" = "#e5c07b";
+          "modified.background" = null;
+          "modified.border" = null;
+          "predictive" = "#4D5970";
+          "predictive.background" = null;
+          "predictive.border" = null;
+          "renamed" = null;
+          "renamed.background" = null;
+          "renamed.border" = null;
+          "success" = null;
+          "success.background" = null;
+          "success.border" = null;
+          "unreachable" = null;
+          "unreachable.background" = null;
+          "unreachable.border" = null;
+          "warning" = "#d19a66";
+          "warning.background" = "#1e2227";
+          "warning.border" = "#89734d";
+          players = [
+            {
+              cursor = "#74ade8ff";
+              background = "#74ade8ff";
+              selection = "#74ade83d";
+            }
+            {
+              cursor = "#be5046ff";
+              background = "#be5046ff";
+              selection = "#be50463d";
+            }
+            {
+              cursor = "#bf956aff";
+              background = "#bf956aff";
+              selection = "#bf956a3d";
+            }
+            {
+              cursor = "#b477cfff";
+              background = "#b477cfff";
+              selection = "#b477cf3d";
+            }
+            {
+              cursor = "#6eb4bfff";
+              background = "#6eb4bfff";
+              selection = "#6eb4bf3d";
+            }
+            {
+              cursor = "#d07277ff";
+              background = "#d07277ff";
+              selection = "#d072773d";
+            }
+            {
+              cursor = "#dec184ff";
+              background = "#dec184ff";
+              selection = "#dec1843d";
+            }
+            {
+              cursor = "#a1c181ff";
+              background = "#a1c181ff";
+              selection = "#a1c1813d";
+            }
+          ];
+          syntax = {
+            comment = {
+              color = "#7F838C";
+              font_style = null;
+              font_weight = null;
+            };
+            attribute = {
+              color = "#d19a66";
+              font_style = null;
+              font_weight = null;
+            };
+            constant = {
+              color = "#d19a66";
+              font_style = null;
+              font_weight = null;
+            };
+            constructor = {
+              color = "#e06c75";
+              font_style = null;
+              font_weight = null;
+            };
+            embedded = {
+              color = "#abb2bf";
+              font_style = null;
+              font_weight = null;
+            };
+            "function" = {
+              color = "#61afef";
+              font_style = null;
+              font_weight = null;
+            };
+            keyword = {
+              color = "#c678dd";
+              font_style = null;
+              font_weight = null;
+            };
+            number = {
+              color = "#d19a66";
+              font_style = null;
+              font_weight = null;
+            };
+            operator = {
+              color = "#abb2bf";
+              font_style = null;
+              font_weight = null;
+            };
+            property = {
+              color = "#e06c75";
+              font_style = null;
+              font_weight = null;
+            };
+            string = {
+              color = "#98c379";
+              font_style = null;
+              font_weight = null;
+            };
+            "string.escape" = {
+              color = "#98c379";
+              font_style = null;
+              font_weight = null;
+            };
+            "string.regex" = {
+              color = "#98c379";
+              font_style = null;
+              font_weight = null;
+            };
+            "string.special" = {
+              color = "#56b6c2";
+              font_style = null;
+              font_weight = null;
+            };
+            "string.special.symbol" = {
+              color = "#56b6c2";
+              font_style = null;
+              font_weight = null;
+            };
+            tag = {
+              color = "#e06c75";
+              font_style = null;
+              font_weight = null;
+            };
+            "text.literal" = {
+              color = "#98c379";
+              font_style = null;
+              font_weight = null;
+            };
+            type = {
+              color = "#e5c07b";
+              font_style = null;
+              font_weight = null;
+            };
+            variable = {
+              color = "#e06c75";
+              font_style = null;
+              font_weight = null;
+            };
+            "variable.special" = {
+              color = "#e5c07b";
+              font_style = null;
+              font_weight = null;
+            };
+          };
+        };
+      }
+    ];
+  };
+in
+{
+  programs.zed-editor = lib.optionalAttrs pkgs.stdenv.isLinux {
+    enable = true;
+    userSettings = zedSettings;
+    themes = {
+      "One_Dark_Pro" = zedTheme;
+    };
+  };
+
+  home.file = lib.optionalAttrs pkgs.stdenv.isDarwin {
+    ".config/zed/settings.json".text = builtins.toJSON zedSettings;
+    ".config/zed/themes/One_Dark_Pro.json".text = builtins.toJSON zedTheme;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `modules/home/zed.nix` with Zed editor settings and custom One Dark Pro theme declared inline as Nix expressions
- Removes `.config/zed` dotfiles symlinks from all three host configs (`john-air-03`, `john-mbp-04`, `john-nix-05`), replacing them with declarative home-manager management
- Linux hosts use `programs.zed-editor` with `userSettings` and `themes`; Darwin hosts use `home.file` to deploy `settings.json` and `themes/One_Dark_Pro.json` to the canonical `~/.config/zed/` paths Zed expects