### PR TITLE
fix(waybar): enable systemd service and pin battery to BAT0

### DIFF
--- a/modules/desktop/hypr/default.nix
+++ b/modules/desktop/hypr/default.nix
@@ -11,7 +11,6 @@ in
 {
   home.packages = with pkgs; [
     rofi
-    waybar
     hyprshot
     brightnessctl
     playerctl
@@ -64,7 +63,6 @@ in
       exec-once = [
         "gnome-keyring-daemon --start --components=secrets"
         terminal
-        "waybar"
         "hyprpaper"
         "hypridle"
 

--- a/modules/desktop/hypr/waybar.nix
+++ b/modules/desktop/hypr/waybar.nix
@@ -1,6 +1,7 @@
 {
   programs.waybar = {
     enable = true;
+    systemd.enable = true;
     settings = [
       {
         reload_style_on_change = true;
@@ -77,6 +78,7 @@
           interval = 5;
         };
         battery = {
+          bat = "BAT0";
           format = "{capacity}% {icon}  ";
           "format-discharging" = "{capacity}% {icon}  ";
           "format-charging" = "{capacity}% {icon}  ";


### PR DESCRIPTION
## Problem

Waybar crashes on suspend/DPMS-off and requires manual restarts. No process supervision exists — `exec-once` is fire-and-forget with no restart on crash.

## Root Cause

- Waybar loses its Wayland display connection when the compositor tears down outputs during DPMS-off (330s) or suspend (1800s) cycles ([upstream #3424](https://github.com/Alexays/Waybar/issues/3424), [#4361](https://github.com/Alexays/Waybar/issues/4361))
- `Battery::refreshBatteries()` throws uncaught exceptions when iterating non-standard power supply entries (`hid-*`, `ucsi-source-psy-*`)

## Changes

| File | Change |
|------|--------|
| `modules/desktop/hypr/waybar.nix` | Add `systemd.enable = true;` and `bat = "BAT0";` |
| `modules/desktop/hypr/default.nix` | Remove `"waybar"` from `exec-once`; remove `waybar` from `home.packages` |

## Why

- `systemd.enable = true` creates a `waybar.service` user unit with `Restart=on-failure`, bound to `hyprland-session.target` — auto-restarts after every crash
- `bat = "BAT0"` pins battery enumeration to avoid exceptions from non-standard power supply entries
- Removing `exec-once "waybar"` prevents duplicate instances racing with the systemd-managed lifecycle
- Removing `waybar` from `home.packages` eliminates redundancy with `programs.waybar.enable = true`

## Post-Deploy (one-time)

After `just nr`, manually bridge the current session:
```bash
systemctl --user start waybar.service
```
Future crashes will auto-recover without intervention.