### PR TITLE
revert(waybar): restore exec-once launch and remove systemd service

### DIFF
--- a/modules/desktop/hypr/default.nix
+++ b/modules/desktop/hypr/default.nix
@@ -11,6 +11,7 @@ in
 {
   home.packages = with pkgs; [
     rofi
+    waybar
     hyprshot
     brightnessctl
     playerctl
@@ -63,6 +64,7 @@ in
       exec-once = [
         "gnome-keyring-daemon --start --components=secrets"
         terminal
+        "waybar"
         "hyprpaper"
         "hypridle"
 

--- a/modules/desktop/hypr/waybar.nix
+++ b/modules/desktop/hypr/waybar.nix
@@ -1,7 +1,6 @@
 {
   programs.waybar = {
     enable = true;
-    systemd.enable = true;
     settings = [
       {
         reload_style_on_change = true;
@@ -78,7 +77,6 @@
           interval = 5;
         };
         battery = {
-          bat = "BAT0";
           format = "{capacity}% {icon}  ";
           "format-discharging" = "{capacity}% {icon}  ";
           "format-charging" = "{capacity}% {icon}  ";


### PR DESCRIPTION
## Reason

Waybar does not start on Hyprland login with the systemd service approach. Reverting to `exec-once` until the root cause of the systemd activation failure is diagnosed.

## Changes Reverted

| File | Restored |
|------|--------|
| `modules/desktop/hypr/waybar.nix` | Remove `systemd.enable = true;` and `bat = "BAT0";` |
| `modules/desktop/hypr/default.nix` | Restore `"waybar"` to `exec-once`; restore `waybar` to `home.packages` |

Reverts #62.