### PR TITLE
feat(bash): migrate .bashrc from dotfiles to Nix module

### DIFF
--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -1,17 +1,12 @@
-{ config, ... }:
-let
-  mkDotfilesSymlink = import ../../lib/dotfiles.nix { inherit config; };
-in
+{ ... }:
 {
   imports = [
-    # Dotfiles configuration
-    ../../modules/home/dotfiles.nix
-
     # Common terminal tools
     ../../modules/home/common.nix
     ../../modules/home/workstation.nix
 
     # Additional config
+    ../../modules/home/bash.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
@@ -27,10 +22,6 @@ in
 
   home.username = "john";
   home.homeDirectory = "/Users/john";
-
-  home.file = {
-    ".bashrc".source = mkDotfilesSymlink ".bashrc";
-  };
 
   # Set your Home Manager state version.
   home.stateVersion = "25.05"; # Or your current version

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -1,21 +1,12 @@
-{
-  pkgs,
-  config,
-  ...
-}:
-let
-  mkDotfilesSymlink = import ../../lib/dotfiles.nix { inherit config; };
-in
+{ pkgs, ... }:
 {
   imports = [
-    # Dotfiles configuration
-    ../../modules/home/dotfiles.nix
-
     # Common terminal tools
     ../../modules/home/common.nix
     ../../modules/home/workstation.nix
 
     # Additional config
+    ../../modules/home/bash.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
@@ -36,10 +27,6 @@ in
 
   home.username = "john";
   home.homeDirectory = "/Users/john";
-
-  home.file = {
-    ".bashrc".source = mkDotfilesSymlink ".bashrc";
-  };
 
   # Set your Home Manager state version.
   home.stateVersion = "25.05"; # Or your current version

--- a/modules/home/bash.nix
+++ b/modules/home/bash.nix
@@ -1,0 +1,6 @@
+{
+  programs.bash = {
+    enable = true;
+    enableCompletion = true;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `modules/home/bash.nix` — a minimal `programs.bash` module (`enable + enableCompletion`)
- Removes the `mkDotfilesSymlink ".bashrc"` symlink from both Darwin hosts
- Removes the now-dead `mkDotfilesSymlink` let binding, `dotfiles.nix` import, and `home.file` block from `john-air-03` and `john-mbp-04` (`opencode.nix` self-manages its own dotfiles dependency)

## Why the dotfiles .bashrc content is dropped

| `.bashrc` content | Disposition |
|---|---|
| Custom git prompt (`__bash_prompt`) | Superseded by Starship (`enableBashIntegration` already set) |
| Aliases (`lg`, `cat`, `ldock`) | Already declared in `home.shellAliases` per host |
| `bash-completion` sourcing | Handled by `programs.bash.enableCompletion` |
| Cargo env / GOPATH | Stale — not used on Darwin |
| fzf sourcing | Stale — not configured via Nix |
| Debian boilerplate (history, checkwinsize, color prompt) | Superseded by `programs.bash` defaults |

All shell integrations (starship, zoxide, direnv, ghostty) are already wired via `enableBashIntegration = true` in their respective modules and will be injected into the Home Manager-managed `.bashrc` automatically.

## State after this PR

`mkDotfilesSymlink` has zero references in `hosts/`. Only `modules/home/opencode.nix` and `lib/dotfiles.nix` itself retain references — cleanup of those is tracked separately.

## Validation

- `nix flake check --no-build` passes

Closes #53 (bashrc portion)