### PR TITLE
fix: separate opencode nix module from config source directory

### DIFF
--- a/hosts/heimdall/john/home.nix
+++ b/hosts/heimdall/john/home.nix
@@ -11,7 +11,7 @@
 
     # Host-specific config
     ../../../modules/home/helix.nix
-    ../../../modules/home/opencode
+    ../../../modules/home/opencode.nix
     ../../../modules/home/zsh.nix
   ];
 

--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -9,7 +9,7 @@
     ../../modules/home/bash.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
-    ../../modules/home/opencode
+    ../../modules/home/opencode.nix
     ../../modules/home/zed.nix
     ../../modules/home/zsh.nix
   ];

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -9,7 +9,7 @@
     ../../modules/home/bash.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
-    ../../modules/home/opencode
+    ../../modules/home/opencode.nix
     ../../modules/home/zed.nix
     ../../modules/home/zsh.nix
   ];

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -22,7 +22,7 @@
     ../../modules/home/alacritty.nix
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
-    ../../modules/home/opencode
+    ../../modules/home/opencode.nix
     ../../modules/home/rclone.nix
     ../../modules/home/zed.nix
     ../../modules/home/zsh.nix

--- a/modules/home/opencode.nix
+++ b/modules/home/opencode.nix
@@ -1,7 +1,7 @@
 { ... }:
 {
   xdg.configFile."opencode" = {
-    source = ./.;
+    source = ./opencode;
     recursive = true;
   };
 


### PR DESCRIPTION
## Root Cause

`modules/home/opencode/default.nix` used `source = ./.` to deploy the opencode config via `xdg.configFile`. Because the source pointed to the directory containing the module itself, `default.nix` was included in the files symlinked into `~/.config/opencode/`. This caused home-manager to fail to create the managed path on `nixos-rebuild switch`.

## Fix

Adopts the canonical pattern for modules that manage config files:

- **Created** `modules/home/opencode.nix` — flat module file with `source = ./opencode` pointing to the sibling directory
- **Deleted** `modules/home/opencode/default.nix` — `opencode/` is now a pure config directory (no `.nix` files)
- **Updated** 4 host imports (`john-nix-05`, `john-mbp-04`, `john-air-03`, `heimdall/john`) from `modules/home/opencode` → `modules/home/opencode.nix`

`~/.config/opencode/` will now only contain `opencode.jsonc`, `AGENTS.md`, and `agent/*.md` — no stray `default.nix`.