### PR TITLE
fix(ghostty): set package = null on Darwin to allow Homebrew-managed install

### DIFF
--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -3,6 +3,7 @@
   programs = {
     ghostty = {
       enable = true;
+      package = if pkgs.stdenv.isDarwin then null else pkgs.ghostty;
       enableZshIntegration = true;
       enableFishIntegration = true;
       enableBashIntegration = true;


### PR DESCRIPTION
## Problem

Running `nix-darwin` switch on `john-air-03` (`aarch64-darwin`) failed with:

```
error: Refusing to evaluate package 'ghostty-1.2.3' because it is not available on the requested hostPlatform:
  hostPlatform.system = "aarch64-darwin"
  package.meta.platforms = [ "aarch64-linux" "x86_64-linux" ... ]
```

The `programs.ghostty` home-manager module defaults `package` to `pkgs.ghostty`, which is a Linux-only GTK build. Nixpkgs cannot build Ghostty from source on macOS due to missing Swift 6 and `xcodebuild` support in the Nix sandbox.

## Root Cause

`modules/home/ghostty.nix` is shared across all hosts (Linux and Darwin). It enables `programs.ghostty` without specifying a `package`, so home-manager falls through to `pkgs.ghostty` — a package that explicitly excludes Darwin from `meta.platforms`.

On macOS, ghostty is intentionally installed via Homebrew cask (`modules/darwin/packages/common.nix`), not through nixpkgs.

## Fix

Set `package = null` on Darwin, which instructs home-manager to manage the config file (theme, fonts, keybinds, shell integration, etc.) without attempting to install the package — leaving that to Homebrew.

```nix
package = if pkgs.stdenv.isDarwin then null else pkgs.ghostty;
```

This follows the same `if pkgs.stdenv.isDarwin` inline conditional pattern used elsewhere in this codebase (e.g. `workstation.nix` for nvtop variants, `zsh.nix` for Homebrew PATH init). The `package = null` behaviour for this use case was introduced in home-manager [issue #6295](https://github.com/nix-community/home-manager/issues/6295).

## Impact

| Host | Platform | Effect |
|---|---|---|
| `john-air-03` | `aarch64-darwin` | HM writes config; Homebrew owns binary |
| `john-mbp-04` | `x86_64-darwin` | HM writes config; Homebrew owns binary |
| `john-nix-05` | `x86_64-linux` | Unchanged — `pkgs.ghostty` installed as before |
| `heimdall` | `x86_64-linux` | Unaffected — does not import `ghostty.nix` |

No functional change to ghostty behaviour on any host. Darwin rebuilds now succeed.