### PR TITLE
refactor: move starship, zellij, zoxide to workstation module

### DIFF
--- a/hosts/apollo/dietpi/home.nix
+++ b/hosts/apollo/dietpi/home.nix
@@ -1,31 +1,10 @@
-{ pkgs, ... }:
+{ ... }:
 {
   imports = [
-    ../../../modules/home/common.nix
-    ../../../modules/home/helix.nix
-    ../../../modules/home/zsh.nix
+    ../../../modules/home/server.nix
   ];
-
-  custom.zellij.enableAutoStart = false;
-
-  home.file.".terminfo" = {
-    source = "${pkgs.ghostty.terminfo}/share/terminfo";
-    recursive = true;
-  };
 
   home.username = "dietpi";
   home.homeDirectory = "/home/dietpi";
   home.stateVersion = "25.05";
-
-  home.packages = with pkgs; [
-    gh
-  ];
-
-  home.shellAliases = {
-    lg = "lazygit";
-    cat = "bat";
-  };
-
-  xdg.enable = true;
-  programs.home-manager.enable = true;
 }

--- a/hosts/heimdall/john/home.nix
+++ b/hosts/heimdall/john/home.nix
@@ -1,49 +1,14 @@
-{ pkgs, ... }:
+{ ... }:
 {
   imports = [
-    # Common terminal tools (shared across all hosts)
-    # Includes: bottom, starship, direnv, bat, git, zoxide, zellij
-    # Packages: fd, fzf, hyperfine, lazygit, ripgrep, tree
-    ../../../modules/home/common.nix
+    ../../../modules/home/server.nix
 
     # AI/development packages
     ../../../modules/packages/ai.nix
-
-    # Host-specific config
-    ../../../modules/home/helix.nix
     ../../../modules/home/opencode.nix
-    ../../../modules/home/zsh.nix
   ];
-
-  # Server-specific: disable zellij auto-start to prevent nested sessions when SSH'd from workstation
-  custom.zellij.enableAutoStart = false;
-
-  # Ghostty terminfo: system ncurses 6.4 compiles a corrupted entry;
-  # use the Nix-built terminfo (ncurses 6.6) to ensure correct terminal capabilities
-  home.file.".terminfo" = {
-    source = "${pkgs.ghostty.terminfo}/share/terminfo";
-    recursive = true;
-  };
 
   home.username = "john";
   home.homeDirectory = "/home/john";
-
   home.stateVersion = "25.05";
-
-  # Server packages
-  home.packages = with pkgs; [
-    gh
-  ];
-
-  # Aliases
-  home.shellAliases = {
-    lg = "lazygit";
-    cat = "bat";
-  };
-
-  # Enable XDG
-  xdg.enable = true;
-
-  # Let Home Manager install and manage itself.
-  programs.home-manager.enable = true;
 }

--- a/modules/home/common.nix
+++ b/modules/home/common.nix
@@ -6,9 +6,6 @@
     ./direnv.nix
     ./git.nix
     ./jujutsu.nix
-    ./starship.nix
-    ./zellij.nix
-    ./zoxide.nix
   ];
 
   # Terminal tools managed by nixpkgs (previously in Homebrew brews)

--- a/modules/home/server.nix
+++ b/modules/home/server.nix
@@ -1,0 +1,29 @@
+{ pkgs, ... }:
+{
+  imports = [
+    ./common.nix
+    ./helix.nix
+    ./zsh.nix
+  ];
+
+  programs.zsh.initContent = ''
+    PROMPT="%{$fg_bold[yellow]%}%n@%m%{$reset_color%} $PROMPT"
+  '';
+
+  # Ghostty terminfo: system ncurses 6.4 compiles a corrupted entry;
+  # use the Nix-built terminfo (ncurses 6.6) to ensure correct terminal capabilities
+  home.file.".terminfo" = {
+    source = "${pkgs.ghostty.terminfo}/share/terminfo";
+    recursive = true;
+  };
+
+  home.packages = with pkgs; [ gh ];
+
+  home.shellAliases = {
+    lg = "lazygit";
+    cat = "bat";
+  };
+
+  xdg.enable = true;
+  programs.home-manager.enable = true;
+}

--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -1,5 +1,11 @@
 { pkgs, ... }:
 {
+  imports = [
+    ./starship.nix
+    ./zellij.nix
+    ./zoxide.nix
+  ];
+
   home.packages = with pkgs; [
     lazydocker
     (if stdenv.isDarwin then nvtopPackages.apple else nvtopPackages.intel)

--- a/modules/home/zellij.nix
+++ b/modules/home/zellij.nix
@@ -1,25 +1,15 @@
-{ pkgs, lib, config, ... }:
+{ pkgs, ... }:
 {
-  options.custom.zellij = {
-    enableAutoStart = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Enable zellij auto-start in zsh (disable for SSH servers)";
-    };
-  };
+  programs.zellij = {
+    enable = true;
+    enableZshIntegration = true;
 
-  config = {
-    programs.zellij = {
-      enable = true;
-      enableZshIntegration = config.custom.zellij.enableAutoStart;
-
-      settings = {
-        theme = "tokyo-night-dark";
-        pane_frames = true;
-        copy_command = if pkgs.stdenv.isLinux then "wl-copy" else "pbcopy";
-        show_startup_tips = false;
-        scroll_buffer_size = 100000;
-      };
+    settings = {
+      theme = "tokyo-night-dark";
+      pane_frames = true;
+      copy_command = if pkgs.stdenv.isLinux then "wl-copy" else "pbcopy";
+      show_startup_tips = false;
+      scroll_buffer_size = 100000;
     };
   };
 }


### PR DESCRIPTION
## Summary

Establishes a clean two-tier module structure for workstations vs servers, and DRYs up duplicated server host config into a shared `server.nix`.

## Changes

| File | Change |
|---|---|
| `modules/home/common.nix` | Remove `starship`, `zellij`, `zoxide` imports — now a true base layer |
| `modules/home/workstation.nix` | Add `starship`, `zellij`, `zoxide` imports |
| `modules/home/zellij.nix` | Remove dead `custom.zellij.enableAutoStart` option; unconditionally enable auto-start |
| `modules/home/server.nix` | **New** — consolidates shared server config (common, helix, zsh, terminfo, gh, aliases) |
| `hosts/apollo/dietpi/home.nix` | Replaced with minimal identity-only config importing `server.nix` |
| `hosts/heimdall/john/home.nix` | Replaced with minimal config importing `server.nix` + host-specific ai/opencode modules |

## Module hierarchy

```
common.nix        ← all hosts (bat, bottom, direnv, git, jujutsu)
├── server.nix    ← servers (+ helix, zsh, terminfo, gh)
└── workstation.nix ← workstations (+ starship, zellij, zoxide)
```

## Validation

- Workstations (`john-nix-05`, `john-mbp-04`, `john-air-03`): no change in behaviour
- Servers: no starship/zoxide/zellij; shared config managed in one place