### PR TITLE
feat: migrate atlas dotfiles to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,11 @@
           username = "dietpi";
           system = "aarch64-linux";
         };
+        "dietpi@atlas" = mkStandaloneHome {
+          hostname = "atlas";
+          username = "dietpi";
+          system = "aarch64-linux";
+        };
       };
     };
 }

--- a/hosts/atlas/dietpi/home.nix
+++ b/hosts/atlas/dietpi/home.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  imports = [
+    ../../../modules/home/server.nix
+  ];
+
+  home.username = "dietpi";
+  home.homeDirectory = "/home/dietpi";
+  home.stateVersion = "25.05";
+}

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -1,5 +1,7 @@
 { ... }:
 {
+  home.packages = with pkgs; [ gh ];
+
   programs.git = {
     enable = true;
     includes = [ { path = "~/.gitconfig.local"; } ];

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 {
   home.packages = with pkgs; [ gh ];
 

--- a/modules/home/server.nix
+++ b/modules/home/server.nix
@@ -17,8 +17,6 @@
     recursive = true;
   };
 
-  home.packages = with pkgs; [ gh ];
-
   home.shellAliases = {
     lg = "lazygit";
     cat = "bat";


### PR DESCRIPTION
Closes #69 

Migrates `dietpi@atlas` config to nix.