### PR TITLE
feat: add fish workstation shell config with jj alias parity

### DIFF
--- a/hosts/john-air-03/configuration.nix
+++ b/hosts/john-air-03/configuration.nix
@@ -1,3 +1,4 @@
+{ pkgs, ... }:
 {
   imports = [
     ../../modules/fonts.nix
@@ -21,7 +22,10 @@
   users.users.john = {
     name = "john";
     home = "/Users/john";
+    shell = pkgs.fish;
   };
+
+  programs.fish.enable = true;
 
   system.primaryUser = "john";
   system.stateVersion = 6;

--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -19,6 +19,7 @@
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/zed.nix
+    ../../modules/home/fish.nix
     ../../modules/home/zsh.nix
 
     # Terminal packages

--- a/hosts/john-mbp-04/configuration.nix
+++ b/hosts/john-mbp-04/configuration.nix
@@ -1,3 +1,4 @@
+{ pkgs, ... }:
 {
   imports = [
     ../../modules/fonts.nix
@@ -21,7 +22,10 @@
   users.users.john = {
     name = "john";
     home = "/Users/john";
+    shell = pkgs.fish;
   };
+
+  programs.fish.enable = true;
 
   system.primaryUser = "john";
   system.stateVersion = 6;

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -19,6 +19,7 @@
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/zed.nix
+    ../../modules/home/fish.nix
     ../../modules/home/zsh.nix
 
     # Terminal packages

--- a/hosts/john-nix-05/configuration.nix
+++ b/hosts/john-nix-05/configuration.nix
@@ -74,7 +74,7 @@
       "scanner"
     ];
     ignoreShellProgramCheck = true;
-    shell = pkgs.zsh;
+    shell = pkgs.fish;
   };
 
   # Some programs need SUID wrappers, can be configured further or are
@@ -86,6 +86,7 @@
   # };
 
   # List services that you want to enable:
+  programs.fish.enable = true;
   programs.nix-ld.enable = true;
 
   # This value determines the NixOS release from which the default

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -32,6 +32,7 @@
     ../../modules/home/opencode.nix
     ../../modules/home/rclone.nix
     ../../modules/home/zed.nix
+    ../../modules/home/fish.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/modules/home/direnv.nix
+++ b/modules/home/direnv.nix
@@ -3,6 +3,7 @@
     direnv = {
       enable = true;
       enableBashIntegration = true;
+      enableFishIntegration = true;
       enableZshIntegration = true;
       nix-direnv.enable = true;
     };

--- a/modules/home/fish.nix
+++ b/modules/home/fish.nix
@@ -1,0 +1,80 @@
+{ pkgs, ... }:
+{
+  programs.fish = {
+    enable = true;
+
+    shellAliases = {
+      l = "ls -lFh";
+      jja = "jj abandon";
+      jjb = "jj bookmark";
+      jjbc = "jj bookmark create";
+      jjbd = "jj bookmark delete";
+      jjbf = "jj bookmark forget";
+      jjbl = "jj bookmark list";
+      jjbm = "jj bookmark move";
+      jjbr = "jj bookmark rename";
+      jjbs = "jj bookmark set";
+      jjbt = "jj bookmark track";
+      jjbu = "jj bookmark untrack";
+      jjc = "jj commit";
+      jjcmsg = "jj commit --message";
+      jjd = "jj diff";
+      jjdmsg = "jj desc --message";
+      jjds = "jj desc";
+      jje = "jj edit";
+      jjgcl = "jj git clone";
+      jjgf = "jj git fetch";
+      jjgfa = "jj git fetch --all-remotes";
+      jjgp = "jj git push";
+      jjgpa = "jj git push --all";
+      jjgpd = "jj git push --deleted";
+      jjgpt = "jj git push --tracked";
+      jjl = "jj log";
+      jjla = "jj log -r \"all()\"";
+      jjn = "jj new";
+      jjnt = "jj new \"trunk()\"";
+      jjrb = "jj rebase";
+      jjrbm = "jj rebase -d \"trunk()\"";
+      jjrs = "jj restore";
+      jjsp = "jj split";
+      jjsq = "jj squash";
+      jjst = "jj status";
+    };
+
+    functions = {
+      jjrt = ''
+        cd "$(jj root || echo .)"
+      '';
+
+      jj_prompt_template_raw = ''
+        jj --no-pager log --no-graph -r @ -T "$argv" 2> /dev/null
+      '';
+
+      jj_prompt_template = ''
+        set -l out (jj_prompt_template_raw "$argv")
+        or return 1
+        string replace --all '%' '%%' "$out"
+      '';
+    };
+
+    interactiveShellInit = ''
+      set -g fish_greeting
+      fish_vi_key_bindings
+    '';
+
+    loginShellInit =
+      if pkgs.stdenv.isDarwin then
+        ''
+          if test (uname -m) = arm64
+            if test -x /opt/homebrew/bin/brew
+              eval "$(/opt/homebrew/bin/brew shellenv)"
+            end
+          end
+
+          fish_add_path --move --prepend "/etc/profiles/per-user/$USER/bin"
+          fish_add_path --move --prepend "$HOME/.nix-profile/bin"
+        ''
+      else
+        "";
+  };
+}

--- a/modules/home/zoxide.nix
+++ b/modules/home/zoxide.nix
@@ -10,6 +10,7 @@
   programs.zoxide = {
     enable = true;
     enableBashIntegration = true;
+    enableFishIntegration = true;
     enableZshIntegration = true;
     options = [
       "--cmd cd"


### PR DESCRIPTION
## Summary
- add a new `modules/home/fish.nix` module with fish enablement, vi bindings, Darwin PATH handling, and oh-my-zsh `jj` alias parity (plus `l`)
- keep zsh available while enabling fish for workstation home configs and set fish as the default shell on john-nix-05, john-air-03, and john-mbp-04
- enable fish integration in shared shell tooling (`direnv` and `zoxide`)

## Validation
- `just check`
- `nix build .#nixosConfigurations.john-nix-05.config.system.build.toplevel`