### PR TITLE
feat(hyprland): migrate config to lua

### DIFF
--- a/modules/desktop/hypr/default.nix
+++ b/modules/desktop/hypr/default.nix
@@ -1,8 +1,25 @@
 {
+  lib,
   pkgs,
   ...
 }:
 let
+  lua = lib.generators.mkLuaInline;
+  call = _args: { inherit _args; };
+  bind =
+    keys: dispatcher:
+    call [
+      keys
+      (lua dispatcher)
+    ];
+  bindWith =
+    keys: dispatcher: options:
+    call [
+      keys
+      (lua dispatcher)
+      options
+    ];
+
   terminal = "ghostty";
   fileManager = "cosmic-files";
   menu = "rofi -show drun";
@@ -41,138 +58,367 @@ in
 
   wayland.windowManager.hyprland = {
     enable = true;
-    configType = "hyprlang";
+    configType = "lua";
     settings = {
-      "$mainMod" = "SUPER";
-      "$shiftMod" = "$mainMod + SHIFT";
-      "$terminal" = terminal;
-      "$fileManager" = fileManager;
-      "$menu" = menu;
+      fileManager._var = fileManager;
+      mainMod._var = "SUPER";
+      menu._var = menu;
+      shiftMod._var = lua ''mainMod .. " + SHIFT"'';
+      terminal._var = terminal;
 
       monitor = [
-        "${laptopMonitor},1920x1080@60.05,0x0,1"
-        "${homeMonitor},1920x1080@75,0x-1080,1"
-        "${workMonitor},2560x1440@59.95,1920x-360,1"
+        {
+          output = laptopMonitor;
+          mode = "1920x1080@60.05";
+          position = "0x0";
+          scale = 1;
+        }
+        {
+          output = homeMonitor;
+          mode = "1920x1080@75";
+          position = "0x-1080";
+          scale = 1;
+        }
+        {
+          output = workMonitor;
+          mode = "2560x1440@59.95";
+          position = "1920x-360";
+          scale = 1;
+        }
       ];
 
-      # Assign workspaces to monitors
-      workspace = [
-        "1, monitor:${laptopMonitor}"
-        "2, monitor:${laptopMonitor}"
-        "3, monitor:${laptopMonitor}"
-        "4, monitor:${homeMonitor}"
-        "5, monitor:${homeMonitor}"
-        "6, monitor:${homeMonitor}"
-        "7, monitor:${workMonitor}"
-        "8, monitor:${workMonitor}"
-        "9, monitor:${workMonitor}"
-        "10, monitor:${workMonitor}"
+      workspace_rule = [
+        {
+          workspace = "1";
+          monitor = laptopMonitor;
+        }
+        {
+          workspace = "2";
+          monitor = laptopMonitor;
+        }
+        {
+          workspace = "3";
+          monitor = laptopMonitor;
+        }
+        {
+          workspace = "4";
+          monitor = homeMonitor;
+        }
+        {
+          workspace = "5";
+          monitor = homeMonitor;
+        }
+        {
+          workspace = "6";
+          monitor = homeMonitor;
+        }
+        {
+          workspace = "7";
+          monitor = workMonitor;
+        }
+        {
+          workspace = "8";
+          monitor = workMonitor;
+        }
+        {
+          workspace = "9";
+          monitor = workMonitor;
+        }
+        {
+          workspace = "10";
+          monitor = workMonitor;
+        }
       ];
 
-      exec-once = [
-        "gnome-keyring-daemon --start --components=secrets"
-        terminal
-        "waybar"
-        "hyprpaper"
-        "hypridle"
-
-        # Apps that I want open
-        "thunderbird"
+      on = call [
+        "hyprland.start"
+        (lua ''
+          function()
+            hl.exec_cmd("gnome-keyring-daemon --start --components=secrets")
+            hl.exec_cmd(terminal)
+            hl.exec_cmd("waybar")
+            hl.exec_cmd("hyprpaper")
+            hl.exec_cmd("hypridle")
+            hl.exec_cmd("thunderbird")
+          end
+        '')
       ];
 
       env = [
-        "XCURSOR_SIZE,24"
-        "HYPRCURSOR_SIZE,24"
-        "XCURSOR_THEME,macOS-White"
-        "HYPRCURSOR_THEME,macOS-White"
+        (call [
+          "XCURSOR_SIZE"
+          "24"
+        ])
+        (call [
+          "HYPRCURSOR_SIZE"
+          "24"
+        ])
+        (call [
+          "XCURSOR_THEME"
+          "macOS-White"
+        ])
+        (call [
+          "HYPRCURSOR_THEME"
+          "macOS-White"
+        ])
       ];
 
-      general = {
-        gaps_in = 5;
-        gaps_out = 5;
-        border_size = 1;
-        "col.active_border" = "rgba(33ccffee) rgba(00ff99ee) 45deg";
-        "col.inactive_border" = "rgba(595959aa)";
-        resize_on_border = false;
-        allow_tearing = false;
-        layout = "dwindle";
-      };
-
-      decoration = {
-        rounding = 10;
-        active_opacity = 1.0;
-        inactive_opacity = 1.0;
-        shadow = {
-          enabled = true;
-          range = 4;
-          render_power = 3;
-          color = "rgba(1a1a1aee)";
+      config = {
+        general = {
+          gaps_in = 5;
+          gaps_out = 5;
+          border_size = 1;
+          col = {
+            active_border = {
+              colors = [
+                "rgba(33ccffee)"
+                "rgba(00ff99ee)"
+              ];
+              angle = 45;
+            };
+            inactive_border = "rgba(595959aa)";
+          };
+          resize_on_border = false;
+          allow_tearing = false;
+          layout = "dwindle";
         };
-        blur = {
-          enabled = true;
-          size = 3;
-          passes = 1;
-          vibrancy = 0.1696;
+
+        decoration = {
+          rounding = 10;
+          active_opacity = 1.0;
+          inactive_opacity = 1.0;
+          shadow = {
+            enabled = true;
+            range = 4;
+            render_power = 3;
+            color = "rgba(1a1a1aee)";
+          };
+          blur = {
+            enabled = true;
+            size = 3;
+            passes = 1;
+            vibrancy = 0.1696;
+          };
         };
-      };
 
-      animations = {
-        enabled = "yes, please :)";
-        bezier = [
-          "easeOutQuint,0.23,1,0.32,1"
-          "easeInOutCubic,0.65,0.05,0.36,1"
-          "linear,0,0,1,1"
-          "almostLinear,0.5,0.5,0.75,1.0"
-          "quick,0.15,0,0.1,1"
-        ];
-        animation = [
-          "global, 1, 10, default"
-          "border, 1, 5.39, easeOutQuint"
-          "windows, 1, 4.79, easeOutQuint"
-          "windowsIn, 1, 4.1, easeOutQuint, popin 87%"
-          "windowsOut, 1, 1.49, linear, popin 87%"
-          "fadeIn, 1, 1.73, almostLinear"
-          "fadeOut, 1, 1.46, almostLinear"
-          "fade, 1, 3.03, quick"
-          "layers, 1, 3.81, easeOutQuint"
-          "layersIn, 1, 4, easeOutQuint, fade"
-          "layersOut, 1, 1.5, linear, fade"
-          "fadeLayersIn, 1, 1.79, almostLinear"
-          "fadeLayersOut, 1, 1.39, almostLinear"
-          "workspaces, 1, 1.94, almostLinear, fade"
-          "workspacesIn, 1, 1.21, almostLinear, fade"
-          "workspacesOut, 1, 1.94, almostLinear, fade"
-        ];
-      };
+        animations.enabled = true;
 
-      dwindle = {
-        preserve_split = true;
-      };
+        dwindle.preserve_split = true;
 
-      master = {
-        new_status = "master";
-      };
+        master.new_status = "master";
 
-      misc = {
-        force_default_wallpaper = 0;
-        disable_hyprland_logo = true;
-      };
+        misc = {
+          force_default_wallpaper = 0;
+          disable_hyprland_logo = true;
+        };
 
-      input = {
-        kb_layout = "us";
-        kb_variant = "";
-        kb_model = "";
-        kb_options = "";
-        kb_rules = "";
-        follow_mouse = 1;
-        natural_scroll = true;
-        sensitivity = 0;
-        touchpad = {
+        input = {
+          kb_layout = "us";
+          kb_variant = "";
+          kb_model = "";
+          kb_options = "";
+          kb_rules = "";
+          follow_mouse = 1;
           natural_scroll = true;
+          sensitivity = 0;
+          touchpad.natural_scroll = true;
         };
       };
 
-      gesture = "3, horizontal, workspace";
+      curve = [
+        (call [
+          "easeOutQuint"
+          {
+            type = "bezier";
+            points = [
+              [
+                0.23
+                1
+              ]
+              [
+                0.32
+                1
+              ]
+            ];
+          }
+        ])
+        (call [
+          "easeInOutCubic"
+          {
+            type = "bezier";
+            points = [
+              [
+                0.65
+                0.05
+              ]
+              [
+                0.36
+                1
+              ]
+            ];
+          }
+        ])
+        (call [
+          "linear"
+          {
+            type = "bezier";
+            points = [
+              [
+                0
+                0
+              ]
+              [
+                1
+                1
+              ]
+            ];
+          }
+        ])
+        (call [
+          "almostLinear"
+          {
+            type = "bezier";
+            points = [
+              [
+                0.5
+                0.5
+              ]
+              [
+                0.75
+                1.0
+              ]
+            ];
+          }
+        ])
+        (call [
+          "quick"
+          {
+            type = "bezier";
+            points = [
+              [
+                0.15
+                0
+              ]
+              [
+                0.1
+                1
+              ]
+            ];
+          }
+        ])
+      ];
+
+      animation = [
+        {
+          leaf = "global";
+          enabled = true;
+          speed = 10;
+          bezier = "default";
+        }
+        {
+          leaf = "border";
+          enabled = true;
+          speed = 5.39;
+          bezier = "easeOutQuint";
+        }
+        {
+          leaf = "windows";
+          enabled = true;
+          speed = 4.79;
+          bezier = "easeOutQuint";
+        }
+        {
+          leaf = "windowsIn";
+          enabled = true;
+          speed = 4.1;
+          bezier = "easeOutQuint";
+          style = "popin 87%";
+        }
+        {
+          leaf = "windowsOut";
+          enabled = true;
+          speed = 1.49;
+          bezier = "linear";
+          style = "popin 87%";
+        }
+        {
+          leaf = "fadeIn";
+          enabled = true;
+          speed = 1.73;
+          bezier = "almostLinear";
+        }
+        {
+          leaf = "fadeOut";
+          enabled = true;
+          speed = 1.46;
+          bezier = "almostLinear";
+        }
+        {
+          leaf = "fade";
+          enabled = true;
+          speed = 3.03;
+          bezier = "quick";
+        }
+        {
+          leaf = "layers";
+          enabled = true;
+          speed = 3.81;
+          bezier = "easeOutQuint";
+        }
+        {
+          leaf = "layersIn";
+          enabled = true;
+          speed = 4;
+          bezier = "easeOutQuint";
+          style = "fade";
+        }
+        {
+          leaf = "layersOut";
+          enabled = true;
+          speed = 1.5;
+          bezier = "linear";
+          style = "fade";
+        }
+        {
+          leaf = "fadeLayersIn";
+          enabled = true;
+          speed = 1.79;
+          bezier = "almostLinear";
+        }
+        {
+          leaf = "fadeLayersOut";
+          enabled = true;
+          speed = 1.39;
+          bezier = "almostLinear";
+        }
+        {
+          leaf = "workspaces";
+          enabled = true;
+          speed = 1.94;
+          bezier = "almostLinear";
+          style = "fade";
+        }
+        {
+          leaf = "workspacesIn";
+          enabled = true;
+          speed = 1.21;
+          bezier = "almostLinear";
+          style = "fade";
+        }
+        {
+          leaf = "workspacesOut";
+          enabled = true;
+          speed = 1.94;
+          bezier = "almostLinear";
+          style = "fade";
+        }
+      ];
+
+      gesture = {
+        fingers = 3;
+        direction = "horizontal";
+        action = "workspace";
+      };
 
       device = {
         name = "epic-mouse-v1";
@@ -180,97 +426,143 @@ in
       };
 
       bind = [
-        "$mainMod, Q, killactive,"
-        "$mainMod, W, killactive,"
-        "$mainMod CTRL, Q, exec, loginctl lock-session"
-        "$mainMod ALT, L, exec, loginctl lock-session"
-        "$mainMod SHIFT, Q, exit,"
-        "$mainMod, E, exec, $fileManager"
-        "$mainMod, M, togglefloating,"
-        "$mainMod, SPACE, exec, $menu"
-        "$mainMod, X, sendshortcut, ctrl, x"
-        "$mainMod, C, sendshortcut, ctrl, c"
-        "$mainMod, V, sendshortcut, ctrl, v"
-        "$mainMod, P, pseudo,"
-        "$mainMod, G, layoutmsg, togglesplit,"
-        "$mainMod, H, movefocus, l"
-        "$mainMod, L, movefocus, r"
-        "$mainMod, K, movefocus, u"
-        "$mainMod, J, movefocus, d"
-        "$mainMod, 1, workspace, 1"
-        "$mainMod, 2, workspace, 2"
-        "$mainMod, 3, workspace, 3"
-        "$mainMod, 4, workspace, 4"
-        "$mainMod, 5, workspace, 5"
-        "$mainMod, 6, workspace, 6"
-        "$mainMod, 7, workspace, 7"
-        "$mainMod, 8, workspace, 8"
-        "$mainMod, 9, workspace, 9"
-        "$mainMod, 0, workspace, 10"
-        "$mainMod CTRL, 1, movetoworkspace, 1"
-        "$mainMod CTRL, 2, movetoworkspace, 2"
-        "$mainMod CTRL, 3, movetoworkspace, 3"
-        "$mainMod CTRL, 4, movetoworkspace, 4"
-        "$mainMod CTRL, 5, movetoworkspace, 5"
-        "$mainMod CTRL, 6, movetoworkspace, 6"
-        "$mainMod CTRL, 7, movetoworkspace, 7"
-        "$mainMod CTRL, 8, movetoworkspace, 8"
-        "$mainMod CTRL, 9, movetoworkspace, 9"
-        "$mainMod CTRL, 0, movetoworkspace, 10"
-        "$mainMod, Left, workspace, e-1"
-        "$mainMod, Right, workspace, e+1"
-        "$mainMod, S, togglespecialworkspace, magic"
-        "$mainMod SHIFT, S, movetoworkspace, special:magic"
-        "$mainMod, mouse_down, workspace, e+1"
-        "$mainMod, mouse_up, workspace, e-1"
-        "$mainMod SHIFT, 3, exec, hyprshot -m output"
-        "$mainMod SHIFT, 4, exec, hyprshot -m region"
-        "$mainMod SHIFT, 5, exec, hyprshot -m window"
-        "$mainMod, F, fullscreen"
-        "$mainMod, TAB, cyclenext"
-        "$mainMod SHIFT, Tab, cyclenext, prev"
-        "$mainMod SHIFT, E, exec, wlogout"
+        (bind (lua ''mainMod .. " + Q"'') "hl.dsp.window.close()")
+        (bind (lua ''mainMod .. " + W"'') "hl.dsp.window.close()")
+        (bind (lua ''mainMod .. " + CTRL + Q"'') ''hl.dsp.exec_cmd("loginctl lock-session")'')
+        (bind (lua ''mainMod .. " + ALT + L"'') ''hl.dsp.exec_cmd("loginctl lock-session")'')
+        (bind (lua ''shiftMod .. " + Q"'') "hl.dsp.exit()")
+        (bind (lua ''mainMod .. " + E"'') "hl.dsp.exec_cmd(fileManager)")
+        (bind (lua ''mainMod .. " + M"'') ''hl.dsp.window.float({ action = "toggle" })'')
+        (bind (lua ''mainMod .. " + SPACE"'') "hl.dsp.exec_cmd(menu)")
+        (bind (lua ''mainMod .. " + X"'') ''hl.dsp.send_shortcut({ mods = "CTRL", key = "X", window = "activewindow" })'')
+        (bind (lua ''mainMod .. " + C"'') ''hl.dsp.send_shortcut({ mods = "CTRL", key = "C", window = "activewindow" })'')
+        (bind (lua ''mainMod .. " + V"'') ''hl.dsp.send_shortcut({ mods = "CTRL", key = "V", window = "activewindow" })'')
+        (bind (lua ''mainMod .. " + P"'') "hl.dsp.window.pseudo()")
+        (bind (lua ''mainMod .. " + G"'') ''hl.dsp.layout("togglesplit")'')
+        (bind (lua ''mainMod .. " + H"'') ''hl.dsp.focus({ direction = "left" })'')
+        (bind (lua ''mainMod .. " + L"'') ''hl.dsp.focus({ direction = "right" })'')
+        (bind (lua ''mainMod .. " + K"'') ''hl.dsp.focus({ direction = "up" })'')
+        (bind (lua ''mainMod .. " + J"'') ''hl.dsp.focus({ direction = "down" })'')
+        (bind (lua ''mainMod .. " + 1"'') "hl.dsp.focus({ workspace = 1 })")
+        (bind (lua ''mainMod .. " + 2"'') "hl.dsp.focus({ workspace = 2 })")
+        (bind (lua ''mainMod .. " + 3"'') "hl.dsp.focus({ workspace = 3 })")
+        (bind (lua ''mainMod .. " + 4"'') "hl.dsp.focus({ workspace = 4 })")
+        (bind (lua ''mainMod .. " + 5"'') "hl.dsp.focus({ workspace = 5 })")
+        (bind (lua ''mainMod .. " + 6"'') "hl.dsp.focus({ workspace = 6 })")
+        (bind (lua ''mainMod .. " + 7"'') "hl.dsp.focus({ workspace = 7 })")
+        (bind (lua ''mainMod .. " + 8"'') "hl.dsp.focus({ workspace = 8 })")
+        (bind (lua ''mainMod .. " + 9"'') "hl.dsp.focus({ workspace = 9 })")
+        (bind (lua ''mainMod .. " + 0"'') "hl.dsp.focus({ workspace = 10 })")
+        (bind (lua ''mainMod .. " + CTRL + 1"'') "hl.dsp.window.move({ workspace = 1 })")
+        (bind (lua ''mainMod .. " + CTRL + 2"'') "hl.dsp.window.move({ workspace = 2 })")
+        (bind (lua ''mainMod .. " + CTRL + 3"'') "hl.dsp.window.move({ workspace = 3 })")
+        (bind (lua ''mainMod .. " + CTRL + 4"'') "hl.dsp.window.move({ workspace = 4 })")
+        (bind (lua ''mainMod .. " + CTRL + 5"'') "hl.dsp.window.move({ workspace = 5 })")
+        (bind (lua ''mainMod .. " + CTRL + 6"'') "hl.dsp.window.move({ workspace = 6 })")
+        (bind (lua ''mainMod .. " + CTRL + 7"'') "hl.dsp.window.move({ workspace = 7 })")
+        (bind (lua ''mainMod .. " + CTRL + 8"'') "hl.dsp.window.move({ workspace = 8 })")
+        (bind (lua ''mainMod .. " + CTRL + 9"'') "hl.dsp.window.move({ workspace = 9 })")
+        (bind (lua ''mainMod .. " + CTRL + 0"'') "hl.dsp.window.move({ workspace = 10 })")
+        (bind (lua ''mainMod .. " + Left"'') ''hl.dsp.focus({ workspace = "e-1" })'')
+        (bind (lua ''mainMod .. " + Right"'') ''hl.dsp.focus({ workspace = "e+1" })'')
+        (bind (lua ''mainMod .. " + S"'') ''hl.dsp.workspace.toggle_special("magic")'')
+        (bind (lua ''shiftMod .. " + S"'') ''hl.dsp.window.move({ workspace = "special:magic" })'')
+        (bind (lua ''mainMod .. " + mouse_down"'') ''hl.dsp.focus({ workspace = "e+1" })'')
+        (bind (lua ''mainMod .. " + mouse_up"'') ''hl.dsp.focus({ workspace = "e-1" })'')
+        (bind (lua ''shiftMod .. " + 3"'') ''hl.dsp.exec_cmd("hyprshot -m output")'')
+        (bind (lua ''shiftMod .. " + 4"'') ''hl.dsp.exec_cmd("hyprshot -m region")'')
+        (bind (lua ''shiftMod .. " + 5"'') ''hl.dsp.exec_cmd("hyprshot -m window")'')
+        (bind (lua ''mainMod .. " + F"'') "hl.dsp.window.fullscreen()")
+        (bind (lua ''mainMod .. " + TAB"'') "hl.dsp.window.cycle_next()")
+        (bind (lua ''shiftMod .. " + Tab"'') "hl.dsp.window.cycle_next({ next = false })")
+        (bind (lua ''shiftMod .. " + E"'') ''hl.dsp.exec_cmd("wlogout")'')
+        (bindWith "XF86AudioRaiseVolume" ''hl.dsp.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+")'' {
+          locked = true;
+          repeating = true;
+        })
+        (bindWith "XF86AudioLowerVolume" ''hl.dsp.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-")'' {
+          locked = true;
+          repeating = true;
+        })
+        (bindWith "XF86AudioMute" ''hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle")'' {
+          locked = true;
+          repeating = true;
+        })
+        (bindWith "XF86AudioMicMute" ''hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle")'' {
+          locked = true;
+          repeating = true;
+        })
+        (bindWith "XF86MonBrightnessUp" ''hl.dsp.exec_cmd("brightnessctl s 10%+")'' {
+          locked = true;
+          repeating = true;
+        })
+        (bindWith "XF86MonBrightnessDown" ''hl.dsp.exec_cmd("brightnessctl s 10%-")'' {
+          locked = true;
+          repeating = true;
+        })
+        (bindWith "XF86AudioNext" ''hl.dsp.exec_cmd("playerctl next")'' { locked = true; })
+        (bindWith "XF86AudioPause" ''hl.dsp.exec_cmd("playerctl play-pause")'' { locked = true; })
+        (bindWith "XF86AudioPlay" ''hl.dsp.exec_cmd("playerctl play-pause")'' { locked = true; })
+        (bindWith "XF86AudioPrev" ''hl.dsp.exec_cmd("playerctl previous")'' { locked = true; })
+        (bindWith (lua ''mainMod .. " + mouse:272"'') "hl.dsp.window.drag()" { mouse = true; })
+        (bindWith (lua ''mainMod .. " + mouse:273"'') "hl.dsp.window.resize()" { mouse = true; })
       ];
 
-      bindel = [
-        ",XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+"
-        ",XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
-        ",XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
-        ",XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
-        ",XF86MonBrightnessUp, exec, brightnessctl s 10%+"
-        ",XF86MonBrightnessDown, exec, brightnessctl s 10%-"
-      ];
-
-      bindl = [
-        ", XF86AudioNext, exec, playerctl next"
-        ", XF86AudioPause, exec, playerctl play-pause"
-        ", XF86AudioPlay, exec, playerctl play-pause"
-        ", XF86AudioPrev, exec, playerctl previous"
-      ];
-
-      bindm = [
-        "$mainMod, mouse:272, movewindow"
-        "$mainMod, mouse:273, resizewindow"
-      ];
-
-      windowrule = [
+      window_rule = [
         # Assign applications to specific workspaces
-        "workspace 1, match:class com.mitchellh.ghostty"
+        {
+          workspace = 1;
+          match.class = "com.mitchellh.ghostty";
+        }
 
         # Thunderbird Main Window - only workspace assignment
-        "workspace 2, match:class ^thunderbird$, match:initial_title ^Mozilla Thunderbird$"
+        {
+          workspace = 2;
+          match = {
+            class = "^thunderbird$";
+            initial_title = "^Mozilla Thunderbird$";
+          };
+        }
 
         # Thunderbird Reminder Window - float, center, size, and workspace 2
-        "workspace 2, match:class ^thunderbird$, match:initial_title ^Calendar Reminders$"
-        "float on, match:class ^thunderbird$, match:initial_title ^Calendar Reminders$"
-        "center on, match:class ^thunderbird$, match:initial_title ^Calendar Reminders$"
-        "size 600 400, match:class ^thunderbird$, match:initial_title ^Calendar Reminders$"
+        {
+          workspace = 2;
+          float = true;
+          center = true;
+          size = "600 400";
+          match = {
+            class = "^thunderbird$";
+            initial_title = "^Calendar Reminders$";
+          };
+        }
 
-        "workspace 4, match:class zen-twilight"
-        "workspace 5, match:class dev.zed.Zed"
-        "workspace 6, match:class Code"
-        "suppress_event maximize, match:class .*"
-        "no_focus on, match:class ^$, match:title ^$, match:xwayland 1, match:float 1, match:fullscreen 0, match:pin 0"
+        {
+          workspace = 4;
+          match.class = "zen-twilight";
+        }
+        {
+          workspace = 5;
+          match.class = "dev.zed.Zed";
+        }
+        {
+          workspace = 6;
+          match.class = "Code";
+        }
+        {
+          suppress_event = "maximize";
+          match.class = ".*";
+        }
+        {
+          no_focus = true;
+          match = {
+            class = "^$";
+            title = "^$";
+            xwayland = true;
+            float = true;
+            fullscreen = false;
+            pin = false;
+          };
+        }
       ];
     };
   };


### PR DESCRIPTION
## Summary
- switch Home Manager Hyprland generation from hyprlang to Lua
- convert monitors, workspace rules, autostart, env, keybinds, animations, gestures, device config, and window rules to Lua API-shaped settings
- preserve existing package list, imports, monitor/workspace layout, commands, and app placement rules

## Verification
- nix flake check
- nix build --no-link .#nixosConfigurations.john-tpd-05.config.system.build.toplevel
- rendered generated hyprland.lua and confirmed keybinds emit hl.bind calls