### PR TITLE
fix: mirror deep-teacher skill for codex

### DIFF
--- a/modules/home/agents.nix
+++ b/modules/home/agents.nix
@@ -4,6 +4,7 @@
   home.file.".codex/AGENTS.md".source = ./agents/AGENTS.md;
 
   home.file.".agents/skills".source = ./agents/skills;
+  home.file.".codex/skills/deep-teacher".source = ./agents/skills/deep-teacher;
 
   xdg.configFile."opencode/AGENTS.md".source = ./agents/AGENTS.md;
 }


### PR DESCRIPTION
## Summary
- mirror the deep-teacher skill into `.codex/skills` for Codex discovery
- leave the existing `.agents/skills` path unchanged for opencode

## Verification
- ran `nixfmt modules/home/agents.nix`
- verified the PR bookmark diff contains only `modules/home/agents.nix`