### PR TITLE
fix: tune Hyprland key repeat

### DIFF
--- a/modules/desktop/hypr/default.nix
+++ b/modules/desktop/hypr/default.nix
@@ -218,6 +218,8 @@ in
           kb_model = "";
           kb_options = "";
           kb_rules = "";
+          repeat_rate = 40;
+          repeat_delay = 250;
           follow_mouse = 1;
           natural_scroll = true;
           sensitivity = 0;


### PR DESCRIPTION
## Summary
- set Hyprland Lua input repeat rate to 40 repeats/sec
- shorten key repeat delay to 250ms for john-tpd-05 Hyprland config

## Verification
- nix flake check