### PR TITLE
fix: use native homebrew cleanup option

### DIFF
--- a/modules/darwin/packages/common.nix
+++ b/modules/darwin/packages/common.nix
@@ -10,10 +10,7 @@
     global.autoUpdate = false;
     onActivation = {
       autoUpdate = true;
-      extraFlags = [
-        "--force-cleanup"
-        "--zap"
-      ];
+      cleanup = "zap";
       upgrade = true;
     };
   };


### PR DESCRIPTION
## Summary
- replace Homebrew activation extraFlags workaround with nix-darwin cleanup = "zap"
- keep existing zap/force-cleanup behavior via upstream nix-darwin support

## Validation
- nix eval .#darwinConfigurations.john-mba-03.config.homebrew.onActivation.cleanup

Closes #80